### PR TITLE
Update Vitalik's blog link

### DIFF
--- a/docs/05-further_reading.md
+++ b/docs/05-further_reading.md
@@ -2,5 +2,5 @@
 
 - [Original paper on Verkle trees](https://math.mit.edu/research/highschool/primes/materials/2018/Kuszmaul.pdf)
 - [Verkle tree EIP](https://notes.ethereum.org/@vbuterin/verkle_tree_eip)
-- [Vitalik's blog post on Verkle trees](https://vitalik.ca/general/2021/06/18/verkle.html)
+- [Vitalik's blog post on Verkle trees](https://vitalik.eth.limo/general/2021/06/18/verkle.html)
 - [Presentation on Verkle tries by Dankrad](https://www.youtube.com/watch?v=RGJOQHzg3UQ)


### PR DESCRIPTION
The previous link to Vitalik's blog link is broken. I've updated it with the right one.